### PR TITLE
Fix ControlPoint dragger issues

### DIFF
--- a/src/Modules/Highlights/highlightConfig.lua
+++ b/src/Modules/Highlights/highlightConfig.lua
@@ -1,0 +1,24 @@
+local Types = require(script.Parent.Parent.Types)
+
+local configs: {[string]: Types.HighlightInfo} = {
+    ["Default"] = {
+        outline = Color3.fromRGB(255, 166, 0),
+        fill = Color3.fromRGB(255, 255, 255),
+        fillTransparency = 0.5,
+        depthMode = Enum.HighlightDepthMode.Occluded
+    },
+    ["Startpoint"] = {
+        outline = Color3.fromRGB(255, 166, 0),
+        fill = Color3.fromRGB(255, 255, 255),
+        fillTransparency = 1,
+        depthMode = Enum.HighlightDepthMode.AlwaysOnTop
+    },
+    ["Endpoint"] = {
+        outline = Color3.fromRGB(255, 166, 0),
+        fill = Color3.fromRGB(255, 255, 255),
+        fillTransparency = 1,
+        depthMode = Enum.HighlightDepthMode.AlwaysOnTop
+    },
+}
+
+return configs

--- a/src/Modules/Highlights/init.lua
+++ b/src/Modules/Highlights/init.lua
@@ -1,0 +1,43 @@
+local packages = script.Parent.Parent.Packages
+local fusion = require(packages.fusion)
+local Types = require(script.Parent.Types)
+local highlightConfigs = require(script.highlightConfig)
+
+return {
+
+    highlights = {},
+
+    addHighlight = function(self, id: string, instance: BasePart | Model | UnionOperation, highlightInfo: Types.HighlightInfo?)
+        if self.highlights[id] then
+            self:removeHighlight(id)
+        end
+
+        if not highlightInfo then
+            highlightInfo = highlightConfigs[id] or highlightConfigs.Default
+        end
+
+        self.highlights[id] = fusion.New "Highlight" {
+            Adornee = instance,
+            FillColor = highlightInfo.fill or Color3.fromRGB(255, 0, 0),
+            OutlineColor = highlightInfo.outline or Color3.fromRGB(255, 255, 255),
+            FillTransparency = highlightInfo.fillTransparency or 0.5,
+            DepthMode = highlightInfo.depthMode or Enum.HighlightDepthMode.AlwaysOnTop,
+            Parent = workspace.CurrentCamera
+        }
+    end,
+
+    removeHighlight = function(self, id: string)
+        if not self.highlights[id] then
+            return
+        end
+
+        self.highlights[id]:Destroy()
+        self.highlights[id] = nil
+    end,
+
+    clearHighlights = function(self)
+        for id, _ in pairs(self.highlights) do
+            self:removeHighlight(id)
+        end
+    end
+}

--- a/src/Modules/PluginUtil/Elements/Instance.lua
+++ b/src/Modules/PluginUtil/Elements/Instance.lua
@@ -32,6 +32,12 @@ end)
 
 game:GetService("UserInputService").InputBegan:Connect(function(input)
     if input.UserInputType == Enum.UserInputType.Keyboard and input.KeyCode == Enum.KeyCode.Escape then
+
+        currentActive:get().Value:set(game.Selection:Get()[1])
+        if currentActive:get().OnChange then
+            currentActive:get().OnChange(currentActive:get().Value:get())
+        end
+
         currentActive:set{
             Value = nil,
             OnChange = nil
@@ -114,7 +120,7 @@ return function(pluginUtil, i: number, elemData: Types.Property<Instance>)
                 BackgroundColor3 = pluginUtil.CONFIG.accentColor,
                 BorderSizePixel = 0,
                 TextColor3 = Computed(function()
-                    if (currentActive:get().Value) or (not cVal:get()) then
+                    if (currentActive:get().Value == cVal) or (not cVal:get()) then
                         return Color3.fromRGB(200, 200, 200)
                     else
                         return Color3.fromRGB(255, 255, 255)
@@ -125,7 +131,7 @@ return function(pluginUtil, i: number, elemData: Types.Property<Instance>)
                 TextTruncate = Enum.TextTruncate.AtEnd,
                 ClipsDescendants = true,
                 Text = Computed(function()
-                    if currentActive:get().Value then
+                    if currentActive:get().Value == cVal then
                         return elemData.SelectingText or "Select instance"
                     end
                     local c = cVal:get()

--- a/src/Modules/Types.lua
+++ b/src/Modules/Types.lua
@@ -1,0 +1,8 @@
+export type HighlightInfo = {
+    outline: Color3,
+    fill: Color3,
+    fillTransparency: number,
+    depthMode: Enum.HighlightDepthMode
+}
+
+return nil

--- a/src/Plugin.server.lua
+++ b/src/Plugin.server.lua
@@ -173,7 +173,7 @@ local function setTemplate()
 			-- Tell plugin to update path on changed
 			controlPoint.Changed:Connect(function()
 				pathChanged = true
-				if not isUpdatingControlPoint and endpoint:get() then
+				if not isUpdatingControlPoint then
 					endpoint:set()
 				end
 			end)

--- a/src/Plugin.server.lua
+++ b/src/Plugin.server.lua
@@ -162,6 +162,7 @@ local function setEndpoint(value: Instance, sign: number?)
 		for _, c in pairs(value:GetDescendants()) do
 			if c:IsA("BasePart") and c.Size.Z > maxSize then
 				p = c
+				maxSize = c.Size.Z
 				break
 			end
 		end

--- a/src/Plugin.server.lua
+++ b/src/Plugin.server.lua
@@ -195,6 +195,8 @@ local function setEndpoint(value: Instance, sign: number?)
 		sign = math.sign(value:GetPivot():PointToObjectSpace(result.Position).Z)
 	end
 
+	endpoint:set(value)
+
 	local relPos = sign * p.Size.Z / 2
 
 	local relCF = CFrame.new(Vector3.new(0, 0, relPos), Vector3.new())
@@ -205,6 +207,7 @@ local function setEndpoint(value: Instance, sign: number?)
 
 	if addConnection then
 		endpointConnection = p:GetPropertyChangedSignal("CFrame"):Connect(function()
+			print("remove")
 			setEndpoint(value, sign)
 		end)
 	end
@@ -351,6 +354,7 @@ pluginUtil:addElementToWidget({
 	Text = "Render Path",
 	OnClick = function()
 		if controlPoint and path.template then
+			isUpdatingControlPoint = true
 			ChangeHistoryService:SetWaypoint("Render Path")
 			previewPath()
 			local folder = path:draw(getTemplateCf(), controlPoint.CFrame, true)
@@ -367,6 +371,7 @@ pluginUtil:addElementToWidget({
 				template:set(tracks[#tracks])
 			end
 			setEndpoint()
+			isUpdatingControlPoint = false
 			setTemplate()
 			ChangeHistoryService:SetWaypoint("Render Path")
 		end

--- a/src/Plugin.server.lua
+++ b/src/Plugin.server.lua
@@ -19,6 +19,8 @@ local Path = require(modules.Path)
 local CreateAssets = require(modules.CreateAssets)
 local pluginUtil = require(modules.PluginUtil)
 local fusion = require(packages.fusion)
+local Types = require(modules.Types)
+local highlights = require(modules.Highlights)
 
 local Value = fusion.Value
 
@@ -46,6 +48,7 @@ local segmentLength = Value(20)
 local cantAngle = Value(0)
 local template = Value()
 local endpoint = Value()
+local endpointConnection: RBXScriptConnection
 
 -- Functions
 
@@ -133,8 +136,9 @@ end
 
 -- Resets the plugin
 local function resetPlugin()
+	highlights:clearHighlights()
 	for _, c in pairs(workspace.CurrentCamera:GetChildren()) do
-		if c.Name == "PathPreview" or c.Name == "ControlPoint" then
+		if c.Name == "PathPreview" or c.Name == "ControlPoint" or c.Name == "Highlight" then
 			c:Destroy()
 		end
 	end
@@ -144,45 +148,115 @@ end
 
 resetPlugin()
 
+local function setEndpoint(value: Instance, sign: number?)
+	highlights:removeHighlight("Endpoint")
+	if endpointConnection then
+		endpointConnection:Disconnect()
+	end
+	if not (value and controlPoint) then endpoint:set() return end
+	local addConnection = value == endpoint:get()
+	local p: nil
+	isUpdatingControlPoint = true
+	if value:IsA("Model") then
+		local maxSize = 0
+		for _, c in pairs(value:GetDescendants()) do
+			if c:IsA("BasePart") and c.Size.Z > maxSize then
+				p = c
+				break
+			end
+		end
+		if maxSize == 0 then endpoint:set() return end
+	elseif value:IsA("BasePart") then
+		p = value
+	else
+		endpoint:set()
+		return
+	end
+
+	highlights:addHighlight("Endpoint", value)
+
+	if not sign then
+
+		local mouse = UserInputService:GetMouseLocation()
+		local ray = workspace.CurrentCamera:ScreenPointToRay(mouse.X, mouse.Y)
+		local rayParams = RaycastParams.new()
+		rayParams.CollisionGroup = "StudioSelectable"
+		local result = workspace:Raycast(ray.Origin, ray.Direction * 500, rayParams)
+		
+		if not (result and ((result.Instance == value) or (result.Instance:IsDescendantOf(value)))) then
+			if template:get() then
+				result = template:get():GetPivot()
+			else
+				return
+			end
+		end
+
+		sign = math.sign(value:GetPivot():PointToObjectSpace(result.Position).Z)
+	end
+
+	local relPos = sign * p.Size.Z / 2
+
+	local relCF = CFrame.new(Vector3.new(0, 0, relPos), Vector3.new())
+	
+	controlPoint.CFrame = value:GetPivot():ToWorldSpace(relCF)
+
+	isUpdatingControlPoint = false
+
+	if addConnection then
+		endpointConnection = p:GetPropertyChangedSignal("CFrame"):Connect(function()
+			setEndpoint(value, sign)
+		end)
+	end
+end
+
 local function setTemplate()
 	ChangeHistoryService:SetWaypoint("Set template")
 	local newSelection = template:get()
 	if path and newSelection then
 		if newSelection:IsA("BasePart") or newSelection:IsA("Model") then
 			path.template = newSelection
-			if controlPoint then
-				controlPoint:Destroy()
+			template:set(newSelection)
+			highlights:addHighlight("Startpoint", newSelection)
+
+			if not endpoint:get() then
+				if controlPoint then
+					controlPoint:Destroy()
+				end
+				controlPoint = assets.ControlPoint:Clone()
+				controlPoint.Parent = workspace.Camera
+				controlPoint.CFrame = getTemplateCf()
+					* (path.length and CFrame.new(0, 0, -path.length) or CFrame.new(0, 0, -10))
+
+				-- Reset when deleted
+				controlPoint.AncestryChanged:Connect(function()
+					if not controlPoint then
+						return
+					end
+					if not controlPoint:IsDescendantOf(game) and path then
+						controlPoint = nil
+						template:set(nil)
+						previewPath()
+					end
+				end)
+
+				-- Tell plugin to update path on changed
+				controlPoint.Changed:Connect(function()
+					pathChanged = true
+					if not isUpdatingControlPoint then
+						setEndpoint()
+					end
+				end)
 			end
-			controlPoint = assets.ControlPoint:Clone()
-			controlPoint.Parent = workspace.Camera
-			controlPoint.CFrame = getTemplateCf()
-				* (path.length and CFrame.new(0, 0, -path.length) or CFrame.new(0, 0, -10))
-
-			-- Reset when deleted
-			controlPoint.AncestryChanged:Connect(function()
-				if not controlPoint then
-					return
-				end
-				if not controlPoint:IsDescendantOf(game) and path then
-					controlPoint = nil
-					template:set(nil)
-					previewPath()
-				end
-			end)
-
-			-- Tell plugin to update path on changed
-			controlPoint.Changed:Connect(function()
-				pathChanged = true
-				if not isUpdatingControlPoint then
-					endpoint:set()
-				end
-			end)
 
 			-- Preview path
 			previewPath(newSelection and path)
 		else
+			highlights:removeHighlight("Startpoint")
 			template:set(nil)
 		end
+	else
+		highlights:removeHighlight("Startpoint")
+		template:set(nil)
 	end
 end
 
@@ -218,6 +292,7 @@ pluginUtil:addElementToWidget({
 	SelectingText = "Select Track Model",
 	EmptyText = "No Track Selected",
 	OnChange = function()
+		Selection:Set({})
 		setTemplate()
 	end,
 })
@@ -225,42 +300,12 @@ pluginUtil:addElementToWidget({
 pluginUtil:addElementToWidget({
 	Type = "Instance",
 	Key = "Endpoint",
-	DefaultValue = nil,
+	DefaultValue = endpoint,
 	SelectingText = "Select endpoint",
 	EmptyText = "ControlPoint",
 	OnChange = function(value) --When endpoint selected, set control point to endpoint
-		if not value then return end;
-		local p: nil
-		isUpdatingControlPoint = true;
-		local mouse = UserInputService:GetMouseLocation()
-		print(mouse.X, mouse.Y)
-		local ray = workspace.CurrentCamera:ScreenPointToRay(mouse.X, mouse.Y)
-		local rayParams = RaycastParams.new()
-		rayParams.CollisionGroup = "StudioSelectable"
-		local result = workspace:Raycast(ray.Origin, ray.Direction * 500, rayParams)
-		if value:IsA("Model") then
-			local maxSize = 0
-			for _, c in pairs(value:GetDescendants()) do
-				if c:IsA("BasePart") and c.Size.Z > maxSize then
-					p = c
-					break
-				end
-			end
-			if maxSize == 0 then endpoint:set() return end;
-		elseif value:IsA("BasePart") then
-			p = value
-		else
-			endpoint:set()
-			return
-		end
-		
-		local relPos = math.sign(value:GetPivot():PointToObjectSpace(result.Position).Z) * p.Size.Z / 2
-
-		local relCF = CFrame.new(Vector3.new(0, 0, relPos), Vector3.new())
-		
-		controlPoint.CFrame = value:GetPivot():ToWorldSpace(relCF)
-
-		isUpdatingControlPoint = false;
+		Selection:Set({})
+		setEndpoint(value)
 	end
 })
 
@@ -309,12 +354,18 @@ pluginUtil:addElementToWidget({
 			previewPath()
 			local folder = path:draw(getTemplateCf(), controlPoint.CFrame, true)
 			path.template = nil
+			local prevEndpoint = endpoint:get()
 			resetPlugin()
 			path = Path.new()
 			path.length = segmentLength:get()
 			path.canting = cantAngle:get()
-			local tracks = folder:GetChildren()
-			template:set(tracks[#tracks])
+			if prevEndpoint then
+				template:set(prevEndpoint)
+			else
+				local tracks = folder:GetChildren()
+				template:set(tracks[#tracks])
+			end
+			setEndpoint()
 			setTemplate()
 			ChangeHistoryService:SetWaypoint("Render Path")
 		end


### PR DESCRIPTION
When dragging ControlPoint, dragger sometimes collides with the preview - this PR aims to fix that.

PR also:
- switches from spawn to BindToRenderStep for preview updates
- adds connection for updates to start instance
- adds dynamic refresh scaling